### PR TITLE
Remove estimated tax field

### DIFF
--- a/src/components/IncomeManager.tsx
+++ b/src/components/IncomeManager.tsx
@@ -534,21 +534,6 @@ export const IncomeManager: React.FC<IncomeManagerProps> = ({ incomes, setIncome
               </>
             )}
 
-            {/* Estimated Tax */}
-            <div>
-              <Label>Estimated Tax Rate</Label>
-              <div className="p-2 bg-slate-100 rounded text-sm font-medium">
-                {newIncome.amount && newIncome.type
-                  ? `${getEffectiveTaxRate(
-                      newIncome.frequency === 'monthly'
-                        ? newIncome.amount * 12
-                        : newIncome.amount,
-                      newIncome.type
-                    ).toFixed(1)}%`
-                  : '0.0%'}
-              </div>
-              <p className="text-xs text-slate-500 mt-1">Auto-calculated</p>
-            </div>
           </div>
 
           <Button onClick={addIncome} className="w-full bg-green-600 hover:bg-green-700">


### PR DESCRIPTION
## Summary
- remove Estimated Tax Rate from income inputs

## Testing
- `npm run lint` *(fails: Unexpected any, prefer-const errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859e7c494848323a6f90b283b117380