### PR TITLE
Add sidebar app shell and mint-style dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,9 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import DashboardPage from "./pages/Dashboard";
 import NotFound from "./pages/NotFound";
+import AppShell from "@/layouts/AppShell";
 
 const queryClient = new QueryClient();
 
@@ -15,7 +17,12 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Index />} />
+          <Route element={<AppShell />}>
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/" element={<Index />} />
+            <Route path="/income" element={<Index />} />
+            <Route path="/settings" element={<Index />} />
+          </Route>
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,28 @@
+import { NavLink } from "react-router-dom";
+import { Home, FileText, DollarSign, Settings as SettingsIcon } from "lucide-react";
+
+const linkClasses = ({ isActive }: { isActive: boolean }) =>
+  `flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium hover:bg-muted ${
+    isActive ? "bg-muted" : ""
+  }`;
+
+export default function Sidebar() {
+  return (
+    <aside className="bg-card h-screen border-r w-56 hidden md:block sticky top-0">
+      <nav className="flex flex-col gap-1 p-2">
+        <NavLink to="/dashboard" className={linkClasses} end>
+          <Home className="w-4 h-4" /> Dashboard
+        </NavLink>
+        <NavLink to="/" className={linkClasses} end>
+          <FileText className="w-4 h-4" /> Expenses
+        </NavLink>
+        <NavLink to="/income" className={linkClasses}>
+          <DollarSign className="w-4 h-4" /> Income
+        </NavLink>
+        <NavLink to="/settings" className={linkClasses}>
+          <SettingsIcon className="w-4 h-4" /> Settings
+        </NavLink>
+      </nav>
+    </aside>
+  );
+}

--- a/src/layouts/AppShell.tsx
+++ b/src/layouts/AppShell.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from "react-router-dom";
+import Sidebar from "@/components/Sidebar";
+
+export default function AppShell() {
+  return (
+    <div className="flex min-h-screen bg-background text-foreground">
+      <Sidebar />
+      <main className="flex-1 overflow-y-auto p-4">
+        <Outlet />
+      </main>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,163 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+const summary = {
+  spending: 4800,
+  cashFlow: 1200,
+  netWorth: 200000,
+};
+
+const expensesData = [
+  { month: "Jan", value: 4500 },
+  { month: "Feb", value: 4600 },
+  { month: "Mar", value: 4700 },
+  { month: "Apr", value: 4200 },
+  { month: "May", value: 4800 },
+  { month: "Jun", value: 5100 },
+];
+
+const cashFlowData = [
+  { month: "Jan", value: 800 },
+  { month: "Feb", value: 900 },
+  { month: "Mar", value: 1000 },
+  { month: "Apr", value: 1100 },
+  { month: "May", value: 1150 },
+  { month: "Jun", value: 1200 },
+];
+
+const upcoming = [
+  { name: "Rent", category: "Housing", date: "2024-07-15", amount: 2500 },
+  { name: "Utilities", category: "Bills", date: "2024-07-18", amount: 200 },
+  { name: "Gym", category: "Health", date: "2024-07-20", amount: 60 },
+];
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-3">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">
+              Monthly Spending
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {formatCurrency(summary.spending)}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Cash Flow</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {formatCurrency(summary.cashFlow)}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium">Net Worth</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {formatCurrency(summary.netWorth)}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">
+            Expense Trend (Jan - Jun)
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={expensesData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+              <XAxis dataKey="month" stroke="#64748b" />
+              <YAxis stroke="#64748b" />
+              <Tooltip formatter={(v: number) => formatCurrency(v)} />
+              <Bar dataKey="value" fill="#3b82f6" />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">Cash Flow Trend</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <ResponsiveContainer width="100%" height={300}>
+            <LineChart data={cashFlowData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+              <XAxis dataKey="month" stroke="#64748b" />
+              <YAxis stroke="#64748b" />
+              <Tooltip formatter={(v: number) => formatCurrency(v)} />
+              <Line dataKey="value" stroke="#10b981" strokeWidth={2} />
+            </LineChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium">
+            Upcoming Transactions
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0 overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="px-4 py-2 text-left">Name</th>
+                <th className="px-4 py-2 text-left">Category</th>
+                <th className="px-4 py-2 text-left">Date</th>
+                <th className="px-4 py-2 text-right">Amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              {upcoming.map((tx) => (
+                <tr key={tx.name} className="border-b hover:bg-muted/50">
+                  <td className="px-4 py-2 whitespace-nowrap">{tx.name}</td>
+                  <td className="px-4 py-2 whitespace-nowrap">{tx.category}</td>
+                  <td className="px-4 py-2 whitespace-nowrap">{tx.date}</td>
+                  <td className="px-4 py-2 text-right whitespace-nowrap">
+                    {formatCurrency(tx.amount)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add sidebar navigation component
- add application shell layout using the sidebar
- create new dashboard page with summary cards, charts, and transactions
- wrap routes in AppShell and expose Dashboard route

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859fd23a69483239c4496f73740a20f