### PR TITLE
Fix realEstateEquity field typo

### DIFF
--- a/src/components/SummaryDashboard.tsx
+++ b/src/components/SummaryDashboard.tsx
@@ -99,7 +99,7 @@ export const SummaryDashboard: React.FC<Props> = ({
   // REAL ESTATE & DEBT
   const realEstateValueByYear = projections.map((p) => p.realEstateValue);
   const loanBalanceByYear = projections.map((p) => p.loanBalance);
-  const realEstateEquityByYear = projections.map((p) => p.realEateEquity);
+  const realEstateEquityByYear = projections.map((p) => p.realEstateEquity);
 
   // Only use the final year's values when showing summaries
   const latestRealEstateValue = realEstateValueByYear[realEstateValueByYear.length - 1] || 0;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -81,7 +81,7 @@ export interface WealthProjection {
   cumulativeWealth: number;
   taxes: number;
   realEstateValue: number;
-  realEateEquity: number;
+  realEstateEquity: number;
   loanBalance: number;
 }
 
@@ -404,7 +404,7 @@ const Index = () => {
         cumulativeWealth,
         taxes,
         realEstateValue,
-        realEateEquity: realEstateEquity,
+        realEstateEquity: realEstateEquity,
         loanBalance: totalLoanBalance
       });
     }
@@ -524,7 +524,7 @@ const Index = () => {
         cumulativeWealth,
         taxes,
         realEstateValue,
-        realEateEquity: realEstateEquity,
+        realEstateEquity: realEstateEquity,
         loanBalance: totalLoanBalance,
       });
     }

--- a/src/services/ExportService.ts
+++ b/src/services/ExportService.ts
@@ -27,7 +27,7 @@ export class ExportService {
       'Cumulative Wealth': projection.cumulativeWealth,
       'Taxes Paid': projection.taxes,
       'Real Estate Value': projection.realEstateValue,
-      'Real Estate Equity': projection.realEateEquity, // <-- FIXED TYPO HERE!
+      'Real Estate Equity': projection.realEstateEquity,
       'Loan Balance': projection.loanBalance
     }));
     


### PR DESCRIPTION
## Summary
- rename field `realEateEquity` to `realEstateEquity` across the app
- update SummaryDashboard and ExportService usages

## Testing
- `npm run lint` *(fails: Unexpected any, prefer-const, and other lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68657775a19c83238d4380e47eec8540