### PR TITLE
Fix cumulative wealth and cleanup export CSV

### DIFF
--- a/src/services/ExportService.ts
+++ b/src/services/ExportService.ts
@@ -27,11 +27,7 @@ export class ExportService {
       'Cumulative Wealth': projection.cumulativeWealth,
       'Taxes Paid': projection.taxes,
       'Real Estate Value': projection.realEstateValue,
-ktyn90-codex/update-real-estate-value-logic
-      'Real Estate Equity': projection.realEateEquity,
-
       'Real Estate Equity': projection.realEstateEquity,
-main
       'Loan Balance': projection.loanBalance
     }));
     


### PR DESCRIPTION
## Summary
- correct real estate equity handling in projections
- avoid double-counting equity when updating wealth
- clean stray text in `ExportService` CSV output

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68657ff8339c8323b928896c829bf8aa