### PR TITLE
Add stacked net worth chart

### DIFF
--- a/src/components/ForecastChart.tsx
+++ b/src/components/ForecastChart.tsx
@@ -3,7 +3,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { LineChart, Line, AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, BarChart, Bar, Legend } from 'recharts';
 import { WealthProjection } from '@/pages/Index';
-import { TrendingUp, BarChart3, LineChart as LineChartIcon, PieChart } from 'lucide-react';
+import { TrendingUp, BarChart3, LineChart as LineChartIcon, PieChart, Layers } from 'lucide-react';
+import NetWorthStackedChart from "@/components/NetWorthStackedChart";
 import { Slider } from '@/components/ui/slider';
 
 interface ForecastChartProps {
@@ -11,7 +12,7 @@ interface ForecastChartProps {
 }
 
 export const ForecastChart: React.FC<ForecastChartProps> = ({ projections }) => {
-  const [chartType, setChartType] = React.useState<'wealth' | 'income' | 'breakdown'>('wealth');
+  const [chartType, setChartType] = React.useState<'wealth' | 'income' | 'breakdown' | 'stacked'>('wealth');
 
   const formatCurrency = (value: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -189,6 +190,9 @@ export const ForecastChart: React.FC<ForecastChartProps> = ({ projections }) => 
           <BarChart3 className="w-4 h-4" />
           Annual Breakdown
         </Button>
+        <Button onClick={() => setChartType('stacked')} className="flex items-center gap-2">
+          <Layers size={16}/> Net-Worth Layers
+        </Button>
       </div>
 
       {/* Chart Display */}
@@ -213,12 +217,26 @@ export const ForecastChart: React.FC<ForecastChartProps> = ({ projections }) => 
                 Annual Financial Breakdown
               </>
             )}
+            {chartType === 'stacked' && (
+              <>
+                <Layers className="w-5 h-5 text-blue-600" />
+                Net-Worth Composition Over Time
+              </>
+            )}
           </CardTitle>
         </CardHeader>
         <CardContent>
           {chartType === 'wealth' && renderWealthChart()}
           {chartType === 'income' && renderIncomeChart()}
           {chartType === 'breakdown' && renderBreakdownChart()}
+          {chartType === 'stacked' && (
+            <>
+              <h3 className="text-lg font-semibold my-2">
+                Net-Worth Composition Over Time
+              </h3>
+              <NetWorthStackedChart data={chartData} currencyFmt={formatCurrency} />
+            </>
+          )}
         </CardContent>
       </Card>
 

--- a/src/components/NetWorthStackedChart.tsx
+++ b/src/components/NetWorthStackedChart.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend
+} from "recharts";
+import { WealthProjection } from "@/pages/Index";
+
+interface Props {
+  data: WealthProjection[];
+  currencyFmt?: (n: number) => string;
+}
+
+const NetWorthStackedChart: React.FC<Props> = ({ data, currencyFmt }) => {
+  const chartData = data.map(d => ({
+    yearLabel: `${new Date().getFullYear() + d.year - 1}`,
+    liquid: d.liquidWealth,
+    realEstate: d.realEstateEquity
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={400}>
+      <AreaChart data={chartData} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
+        <defs>
+          <linearGradient id="liquid" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#60a5fa" stopOpacity={0.8}/>
+            <stop offset="95%" stopColor="#60a5fa" stopOpacity={0}/>
+          </linearGradient>
+          <linearGradient id="realEstate" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="#34d399" stopOpacity={0.8}/>
+            <stop offset="95%" stopColor="#34d399" stopOpacity={0}/>
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="yearLabel" />
+        <YAxis tickFormatter={currencyFmt}/>
+        <Tooltip formatter={currencyFmt}/>
+        <Legend />
+        <Area
+          type="monotone"
+          dataKey="liquid"
+          stackId="1"
+          stroke="#2563eb"
+          fill="url(#liquid)"
+          name="Liquid / Investments"
+        />
+        <Area
+          type="monotone"
+          dataKey="realEstate"
+          stackId="1"
+          stroke="#059669"
+          fill="url(#realEstate)"
+          name="Real-Estate Equity"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default NetWorthStackedChart;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -78,6 +78,7 @@ export interface WealthProjection {
   netIncome: number;
   totalExpenses: number;
   savings: number;
+  liquidWealth: number;
   cumulativeWealth: number;
   taxes: number;
   realEstateValue: number;
@@ -405,6 +406,7 @@ const Index = () => {
         netIncome,
         totalExpenses,
         savings,
+        liquidWealth,
         cumulativeWealth,
         taxes,
         realEstateValue,
@@ -529,6 +531,7 @@ const Index = () => {
         netIncome,
         totalExpenses,
         savings,
+        liquidWealth,
         cumulativeWealth,
         taxes,
         realEstateValue,


### PR DESCRIPTION
## Summary
- extend `WealthProjection` with `liquidWealth`
- store `liquidWealth` in yearly projections
- create `NetWorthStackedChart` for stacked area view of liquid vs real estate wealth
- add stacked chart option to `ForecastChart`

## Testing
- `npm run format` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68658e3eb45483238e523900dc499c60