### PR TITLE
Fix React app mounting and route shell wiring

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,23 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import AppShell from "@/layouts/AppShell";
+import DashboardPage from "@/pages/DashboardPage";
 import ExpensesPage from "@/pages/ExpensesPage";
+import IncomePage from "@/pages/IncomePage";
 import NotFoundPage from "@/pages/NotFoundPage";
+import SettingsPage from "@/pages/SettingsPage";
 
 export default function App() {
   return (
     <BrowserRouter>
-      <AppShell>
-        <Routes>
-          <Route path="/" element={<ExpensesPage />} />
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/" element={<DashboardPage />} />
+          <Route path="/income" element={<IncomePage />} />
+          <Route path="/expenses" element={<ExpensesPage />} />
+          <Route path="/settings" element={<SettingsPage />} />
           <Route path="*" element={<NotFoundPage />} />
-        </Routes>
-      </AppShell>
+        </Route>
+      </Routes>
     </BrowserRouter>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,


### PR DESCRIPTION
### Motivation
- The app layout component `AppShell` uses an `Outlet` so routed pages must be provided via nested routes rather than passed as children. 
- The React entrypoint needs to mount via `ReactDOM.createRoot(...)` and render the app inside `React.StrictMode` to ensure correct initialization.

### Description
- Update `src/main.tsx` to call `ReactDOM.createRoot(document.getElementById("root")!).render(...)` and wrap `<App />` in `<React.StrictMode>`.
- Update `src/App.tsx` to use `BrowserRouter`, `Routes`, and a layout route (`<Route element={<AppShell />}>`) that nests the app routes so `AppShell`'s `Outlet` receives routed content.
- Wire existing pages by importing and adding routes for `DashboardPage` (`/`), `IncomePage` (`/income`), `ExpensesPage` (`/expenses`), `SettingsPage` (`/settings`), and a fallback `*` route to `NotFoundPage`, while keeping changes minimal and introducing no new dependencies.

### Testing
- Ran `npm install` successfully with no dependency changes reported as failing.
- Ran `npm run build` and the production build completed successfully (Vite build succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fba84aff883238a0696ae6f0ccc63)